### PR TITLE
feat: Improve sequence and populate features

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -167,3 +167,70 @@ func Example_sequence() {
 	// Output:
 	// IDs are sequential: true
 }
+
+// Example_sequenceWithStartValue demonstrates sequence with custom start value.
+func Example_sequenceWithStartValue() {
+	type Invoice struct {
+		Number int `gofab:"sequence:1000"`
+	}
+
+	ResetAllSequences()
+
+	invoice := Build[Invoice]()
+	fmt.Printf("Invoice number starts at 1000: %v\n", invoice.Number >= 1000)
+
+	// Output:
+	// Invoice number starts at 1000: true
+}
+
+// Example_resetSequence demonstrates resetting sequences between tests.
+func Example_resetSequence() {
+	type Item struct {
+		ID int `gofab:"sequence"`
+	}
+
+	ResetAllSequences()
+
+	item1 := Build[Item]()
+	item2 := Build[Item]()
+
+	fmt.Printf("First item ID: %d\n", item1.ID)
+	fmt.Printf("Second item ID: %d\n", item2.ID)
+
+	// Reset and build again
+	ResetAllSequences()
+
+	item3 := Build[Item]()
+	fmt.Printf("After reset, item ID: %d\n", item3.ID)
+
+	// Output:
+	// First item ID: 1
+	// Second item ID: 2
+	// After reset, item ID: 1
+}
+
+// Example_newTags demonstrates the new populate tags.
+func Example_newTags() {
+	type Profile struct {
+		UUID     string `gofab:"uuid"`
+		Username string `gofab:"username"`
+		Website  string `gofab:"url"`
+		Active   bool   `gofab:"bool:true"`
+		Status   string `gofab:"oneof:active,pending,inactive"`
+	}
+
+	profile := Build[Profile]()
+
+	fmt.Printf("Has UUID: %v\n", profile.UUID != "")
+	fmt.Printf("Has Username: %v\n", profile.Username != "")
+	fmt.Printf("Has Website: %v\n", profile.Website != "")
+	fmt.Printf("Is Active: %v\n", profile.Active)
+	fmt.Printf("Has Valid Status: %v\n", profile.Status == "active" || profile.Status == "pending" || profile.Status == "inactive")
+
+	// Output:
+	// Has UUID: true
+	// Has Username: true
+	// Has Website: true
+	// Is Active: true
+	// Has Valid Status: true
+}

--- a/populate.go
+++ b/populate.go
@@ -20,6 +20,7 @@ func autoPopulateFromTags(obj any) {
 	}
 
 	t := v.Type()
+	typeName := t.Name()
 
 	for i := 0; i < v.NumField(); i++ {
 		field := v.Field(i)
@@ -38,40 +39,85 @@ func autoPopulateFromTags(obj any) {
 			continue
 		}
 
-		value := generateFromTag(tag, field.Type())
+		// Create a unique key for field-level sequence management
+		sequenceKey := typeName + "." + fieldType.Name
+		value := generateFromTag(tag, field.Type(), sequenceKey)
+
 		if value != nil {
 			setFieldValue(field, value)
 		}
 	}
 }
 
-func generateFromTag(tag string, fieldType reflect.Type) any {
-	return handleTagGeneration(tag, fieldType)
+// tagContext holds context for tag generation.
+type tagContext struct {
+	parts       []string
+	fieldType   reflect.Type
+	sequenceKey string
 }
 
-func handleTagGeneration(tag string, fieldType reflect.Type) any {
+// simpleTagGenerators maps tag names to simple generators (no parameters needed).
+var simpleTagGenerators = map[string]func() any{
+	"name":      func() any { return gofakeit.Name() },
+	"email":     func() any { return gofakeit.Email() },
+	"phone":     func() any { return gofakeit.Phone() },
+	"company":   func() any { return gofakeit.Company() },
+	"word":      func() any { return gofakeit.Word() },
+	"uuid":      func() any { return gofakeit.UUID() },
+	"url":       func() any { return gofakeit.URL() },
+	"username":  func() any { return gofakeit.Username() },
+	"datetime":  func() any { return gofakeit.Date() },
+	"firstname": func() any { return gofakeit.FirstName() },
+	"lastname":  func() any { return gofakeit.LastName() },
+	"city":      func() any { return gofakeit.City() },
+	"country":   func() any { return gofakeit.Country() },
+	"zip":       func() any { return gofakeit.Zip() },
+	"latitude":  func() any { return gofakeit.Latitude() },
+	"longitude": func() any { return gofakeit.Longitude() },
+	"ipv4":      func() any { return gofakeit.IPv4Address() },
+	"ipv6":      func() any { return gofakeit.IPv6Address() },
+	"mac":       func() any { return gofakeit.MacAddress() },
+	"hexcolor":  func() any { return gofakeit.HexColor() },
+	"rgbcolor":  func() any { return gofakeit.RGBColor() },
+	"useragent": func() any { return gofakeit.UserAgent() },
+	"address":   func() any { return gofakeit.Address().Address },
+}
+
+func generateFromTag(tag string, fieldType reflect.Type, sequenceKey string) any {
 	parts := strings.Split(tag, ":")
 	tagName := parts[0]
 
+	// Check simple generators first
+	if generator, ok := simpleTagGenerators[tagName]; ok {
+		return generator()
+	}
+
+	// Handle complex generators that need context
+	ctx := tagContext{
+		parts:       parts,
+		fieldType:   fieldType,
+		sequenceKey: sequenceKey,
+	}
+
+	return handleComplexTag(tagName, ctx)
+}
+
+func handleComplexTag(tagName string, ctx tagContext) any {
 	switch tagName {
-	case "name":
-		return gofakeit.Name()
-	case "email":
-		return gofakeit.Email()
-	case "phone":
-		return gofakeit.Phone()
-	case "company":
-		return gofakeit.Company()
-	case "address":
-		return gofakeit.Address().Address
-	case "word":
-		return gofakeit.Word()
 	case "sentence":
-		return handleSentenceTag(parts)
+		return handleSentenceTag(ctx.parts)
 	case "range":
-		return handleRangeTag(parts)
+		return handleRangeTag(ctx.parts)
 	case "sequence":
-		return generateSequence(fieldType)
+		return generateSequenceForField(ctx.parts, ctx.fieldType, ctx.sequenceKey)
+	case "password":
+		return handlePasswordTag(ctx.parts)
+	case "date":
+		return handleDateTag(ctx.parts)
+	case "bool":
+		return handleBoolTag(ctx.parts)
+	case "oneof":
+		return handleOneOfTag(ctx.parts)
 	default:
 		return nil
 	}
@@ -109,17 +155,84 @@ func handleRangeTag(parts []string) any {
 	return gofakeit.Number(1, 100)
 }
 
-var sequenceCounters = make(map[reflect.Type]*sequenceCounter)
+// handlePasswordTag generates a password.
+// Supports "password" for default (8-16 chars) or "password:N" for specific length.
+func handlePasswordTag(parts []string) any {
+	length := 12
 
-func generateSequence(fieldType reflect.Type) any {
-	counter, exists := sequenceCounters[fieldType]
-	if !exists {
-		counter = &sequenceCounter{value: 0}
-		sequenceCounters[fieldType] = counter
+	if len(parts) == 2 {
+		if l, err := strconv.Atoi(parts[1]); err == nil && l > 0 {
+			length = l
+		}
 	}
 
+	return gofakeit.Password(true, true, true, true, false, length)
+}
+
+// handleDateTag generates a date string.
+// Supports "date" for YYYY-MM-DD format or "date:format" for custom format.
+func handleDateTag(parts []string) any {
+	format := "2006-01-02"
+
+	if len(parts) == 2 {
+		format = parts[1]
+	}
+
+	return gofakeit.Date().Format(format)
+}
+
+// handleBoolTag generates a boolean value.
+// Supports "bool" for random, "bool:true" for always true, "bool:false" for always false.
+func handleBoolTag(parts []string) any {
+	if len(parts) == 2 {
+		switch strings.ToLower(parts[1]) {
+		case "true":
+			return true
+		case "false":
+			return false
+		}
+	}
+
+	return gofakeit.Bool()
+}
+
+// handleOneOfTag selects a random value from the provided options.
+// Usage: "oneof:a,b,c" returns one of "a", "b", or "c".
+func handleOneOfTag(parts []string) any {
+	if len(parts) != 2 {
+		return ""
+	}
+
+	options := strings.Split(parts[1], ",")
+	if len(options) == 0 {
+		return ""
+	}
+
+	for i := range options {
+		options[i] = strings.TrimSpace(options[i])
+	}
+
+	return options[gofakeit.Number(0, len(options)-1)]
+}
+
+// generateSequenceForField generates a sequence value using the global registry.
+// Supports custom start values via "sequence:N" syntax (e.g., "sequence:100").
+func generateSequenceForField(parts []string, fieldType reflect.Type, sequenceKey string) any {
+	startValue := int64(1)
+
+	if len(parts) == 2 {
+		if start, err := strconv.ParseInt(parts[1], 10, 64); err == nil {
+			startValue = start
+		}
+	}
+
+	counter := globalRegistry.getOrCreate(sequenceKey, startValue)
 	next := counter.next()
 
+	return convertSequenceValue(next, fieldType)
+}
+
+func convertSequenceValue(next int64, fieldType reflect.Type) any {
 	switch fieldType.Kind() { //nolint:exhaustive // exhaustive switch is not necessary here
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return int(next)

--- a/sequence.go
+++ b/sequence.go
@@ -1,6 +1,7 @@
 package gofab
 
 import (
+	"sync"
 	"sync/atomic"
 )
 
@@ -12,9 +13,91 @@ func (s *sequenceCounter) next() int64 {
 	return atomic.AddInt64(&s.value, 1)
 }
 
+func (s *sequenceCounter) reset(value int64) {
+	atomic.StoreInt64(&s.value, value)
+}
+
+// sequenceRegistry manages all sequence counters for thread-safe access.
+type sequenceRegistry struct {
+	mu       sync.RWMutex
+	counters map[string]*sequenceCounter
+}
+
+var globalRegistry = &sequenceRegistry{
+	counters: make(map[string]*sequenceCounter),
+}
+
+// getOrCreate returns an existing counter or creates a new one for the given key.
+func (r *sequenceRegistry) getOrCreate(key string, startValue int64) *sequenceCounter {
+	r.mu.RLock()
+	counter, exists := r.counters[key]
+	r.mu.RUnlock()
+
+	if exists {
+		return counter
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if counter, exists = r.counters[key]; exists {
+		return counter
+	}
+
+	counter = &sequenceCounter{value: startValue - 1}
+	r.counters[key] = counter
+
+	return counter
+}
+
+// reset resets a specific counter to the given value.
+func (r *sequenceRegistry) reset(key string, value int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if counter, exists := r.counters[key]; exists {
+		counter.reset(value - 1)
+	}
+}
+
+// resetAll resets all counters to their initial state.
+func (r *sequenceRegistry) resetAll() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.counters = make(map[string]*sequenceCounter)
+}
+
+// ResetSequence resets a specific sequence counter by key.
+// The key format is typically "TypeName.FieldName" for tag-based sequences.
+func ResetSequence(key string) {
+	globalRegistry.reset(key, 1)
+}
+
+// ResetSequenceWithValue resets a specific sequence counter to start from the given value.
+func ResetSequenceWithValue(key string, startValue int64) {
+	globalRegistry.reset(key, startValue)
+}
+
+// ResetAllSequences resets all sequence counters.
+// Useful for test cleanup between test cases.
+func ResetAllSequences() {
+	globalRegistry.resetAll()
+}
+
 // Sequence creates a sequential value builder.
 func Sequence[T any, V any](setter func(*T, V), generator func(int64) V) Builder[T] {
 	counter := &sequenceCounter{value: -1}
+
+	return func(obj *T) {
+		setter(obj, generator(counter.next()))
+	}
+}
+
+// SequenceWithStart creates a sequential value builder starting from a custom value.
+func SequenceWithStart[T any, V any](startValue int64, setter func(*T, V), generator func(int64) V) Builder[T] {
+	counter := &sequenceCounter{value: startValue - 1}
 
 	return func(obj *T) {
 		setter(obj, generator(counter.next()))


### PR DESCRIPTION
## Summary
- Add sequence reset functions (`ResetSequence`, `ResetSequenceWithValue`, `ResetAllSequences`) for test cleanup between test cases
- Add `SequenceWithStart` builder for custom starting values
- Support `sequence:N` tag syntax for custom start values (e.g., `gofab:"sequence:1000"`)
- Implement field-level sequence management using `TypeName.FieldName` keys
- Add new populate tags: `uuid`, `url`, `username`, `password`, `date`, `datetime`, `bool`, `oneof`, `firstname`, `lastname`, `city`, `country`, `zip`, `latitude`, `longitude`, `ipv4`, `ipv6`, `mac`, `hexcolor`, `rgbcolor`, `useragent`

## Test plan
- [x] All existing tests pass
- [x] New Example tests added for sequence reset and new tags
- [x] Lint checks pass