### PR TITLE
feat: Add Association support for automatic related object creation

### DIFF
--- a/association.go
+++ b/association.go
@@ -1,0 +1,143 @@
+package gofab
+
+// AssociationFactory creates instances with associated objects.
+// R is the type that holds all associations.
+type AssociationFactory[T any, R any] struct {
+	defaults     []Builder[T]
+	traits       map[string][]Builder[T]
+	associations func() R
+	linker       func(*T, R)
+}
+
+// DefineWithAssociations creates a new factory with association support.
+// R is a struct type that holds all related objects.
+func DefineWithAssociations[T any, R any](
+	associations func() R,
+	linker func(*T, R),
+	defaults ...Builder[T],
+) *AssociationFactory[T, R] {
+	return &AssociationFactory[T, R]{
+		defaults:     defaults,
+		traits:       make(map[string][]Builder[T]),
+		associations: associations,
+		linker:       linker,
+	}
+}
+
+// Trait defines a named set of attributes that can be applied when building.
+func (f *AssociationFactory[T, R]) Trait(name string, builders ...Builder[T]) *AssociationFactory[T, R] {
+	f.traits[name] = builders
+
+	return f
+}
+
+// WithTrait returns builders for the specified trait.
+func (f *AssociationFactory[T, R]) WithTrait(name string) []Builder[T] {
+	return f.traits[name]
+}
+
+// WithTraits returns builders for multiple traits combined.
+func (f *AssociationFactory[T, R]) WithTraits(names ...string) []Builder[T] {
+	var builders []Builder[T]
+	for _, name := range names {
+		builders = append(builders, f.traits[name]...)
+	}
+
+	return builders
+}
+
+// Build creates an instance with automatically created associations.
+func (f *AssociationFactory[T, R]) Build(builders ...Builder[T]) T {
+	var result T
+
+	autoPopulateFromTags(&result)
+
+	for _, builder := range f.defaults {
+		builder(&result)
+	}
+
+	// Create and link associations
+	if f.associations != nil && f.linker != nil {
+		assoc := f.associations()
+		f.linker(&result, assoc)
+	}
+
+	for _, builder := range builders {
+		builder(&result)
+	}
+
+	return result
+}
+
+// BuildWithAssociations creates an instance and returns both the instance and its associations.
+func (f *AssociationFactory[T, R]) BuildWithAssociations(builders ...Builder[T]) (T, R) {
+	var (
+		result T
+		assoc  R
+	)
+
+	autoPopulateFromTags(&result)
+
+	for _, builder := range f.defaults {
+		builder(&result)
+	}
+
+	// Create and link associations
+	if f.associations != nil {
+		assoc = f.associations()
+
+		if f.linker != nil {
+			f.linker(&result, assoc)
+		}
+	}
+
+	for _, builder := range builders {
+		builder(&result)
+	}
+
+	return result, assoc
+}
+
+// BuildList creates multiple instances with automatically created associations.
+func (f *AssociationFactory[T, R]) BuildList(count int, builders ...Builder[T]) []T {
+	result := make([]T, count)
+	for i := range result {
+		result[i] = f.Build(builders...)
+	}
+
+	return result
+}
+
+// BuildListWithAssociations creates multiple instances and returns both instances and associations.
+func (f *AssociationFactory[T, R]) BuildListWithAssociations(count int, builders ...Builder[T]) ([]T, []R) {
+	results := make([]T, count)
+	assocs := make([]R, count)
+
+	for i := range results {
+		results[i], assocs[i] = f.BuildWithAssociations(builders...)
+	}
+
+	return results, assocs
+}
+
+// WithCustomAssociations allows overriding the default associations for a single build.
+func (f *AssociationFactory[T, R]) WithCustomAssociations(customAssoc R, builders ...Builder[T]) T {
+	var result T
+
+	autoPopulateFromTags(&result)
+
+	for _, builder := range f.defaults {
+		builder(&result)
+	}
+
+	// Link custom associations
+	if f.linker != nil {
+		f.linker(&result, customAssoc)
+	}
+
+	for _, builder := range builders {
+		builder(&result)
+	}
+
+	return result
+}

--- a/association_test.go
+++ b/association_test.go
@@ -1,0 +1,211 @@
+package gofab_test
+
+import (
+	"testing"
+
+	"github.com/sivchari/gofab"
+)
+
+// Test types for association tests.
+type Author struct {
+	ID   int    `gofab:"sequence"`
+	Name string `gofab:"name"`
+}
+
+type Category struct {
+	ID   int    `gofab:"sequence"`
+	Name string `gofab:"word"`
+}
+
+type Post struct {
+	ID         int    `gofab:"sequence"`
+	Title      string `gofab:"sentence:3"`
+	AuthorID   int
+	CategoryID int
+}
+
+type PostRelations struct {
+	Author   Author
+	Category Category
+}
+
+func TestAssociationFactory_Build(t *testing.T) {
+	authorFactory := gofab.Define[Author]()
+	categoryFactory := gofab.Define[Category]()
+
+	postFactory := gofab.DefineWithAssociations[Post, PostRelations](
+		func() PostRelations {
+			return PostRelations{
+				Author:   authorFactory.Build(),
+				Category: categoryFactory.Build(),
+			}
+		},
+		func(p *Post, r PostRelations) {
+			p.AuthorID = r.Author.ID
+			p.CategoryID = r.Category.ID
+		},
+	)
+
+	post := postFactory.Build()
+
+	if post.ID == 0 {
+		t.Error("Post ID should be auto-generated")
+	}
+
+	if post.Title == "" {
+		t.Error("Post Title should be auto-generated")
+	}
+
+	if post.AuthorID == 0 {
+		t.Error("Post AuthorID should be set from association")
+	}
+
+	if post.CategoryID == 0 {
+		t.Error("Post CategoryID should be set from association")
+	}
+}
+
+func TestAssociationFactory_BuildWithAssociations(t *testing.T) {
+	authorFactory := gofab.Define[Author]()
+	categoryFactory := gofab.Define[Category]()
+
+	postFactory := gofab.DefineWithAssociations[Post, PostRelations](
+		func() PostRelations {
+			return PostRelations{
+				Author:   authorFactory.Build(),
+				Category: categoryFactory.Build(),
+			}
+		},
+		func(p *Post, r PostRelations) {
+			p.AuthorID = r.Author.ID
+			p.CategoryID = r.Category.ID
+		},
+	)
+
+	post, relations := postFactory.BuildWithAssociations()
+
+	if post.AuthorID != relations.Author.ID {
+		t.Errorf("Post AuthorID (%d) should match Author ID (%d)", post.AuthorID, relations.Author.ID)
+	}
+
+	if post.CategoryID != relations.Category.ID {
+		t.Errorf("Post CategoryID (%d) should match Category ID (%d)", post.CategoryID, relations.Category.ID)
+	}
+
+	if relations.Author.Name == "" {
+		t.Error("Author Name should be auto-generated")
+	}
+
+	if relations.Category.Name == "" {
+		t.Error("Category Name should be auto-generated")
+	}
+}
+
+func TestAssociationFactory_BuildList(t *testing.T) {
+	authorFactory := gofab.Define[Author]()
+	categoryFactory := gofab.Define[Category]()
+
+	postFactory := gofab.DefineWithAssociations[Post, PostRelations](
+		func() PostRelations {
+			return PostRelations{
+				Author:   authorFactory.Build(),
+				Category: categoryFactory.Build(),
+			}
+		},
+		func(p *Post, r PostRelations) {
+			p.AuthorID = r.Author.ID
+			p.CategoryID = r.Category.ID
+		},
+	)
+
+	posts := postFactory.BuildList(3)
+
+	if len(posts) != 3 {
+		t.Errorf("Expected 3 posts, got %d", len(posts))
+	}
+
+	// Each post should have different associations
+	authorIDs := make(map[int]bool)
+
+	for _, post := range posts {
+		if post.AuthorID == 0 {
+			t.Error("Post AuthorID should be set")
+		}
+
+		authorIDs[post.AuthorID] = true
+	}
+
+	// All posts should have different author IDs (different associations created each time)
+	if len(authorIDs) != 3 {
+		t.Errorf("Expected 3 different author IDs, got %d", len(authorIDs))
+	}
+}
+
+func TestAssociationFactory_WithCustomAssociations(t *testing.T) {
+	authorFactory := gofab.Define[Author]()
+	categoryFactory := gofab.Define[Category]()
+
+	postFactory := gofab.DefineWithAssociations[Post, PostRelations](
+		func() PostRelations {
+			return PostRelations{
+				Author:   authorFactory.Build(),
+				Category: categoryFactory.Build(),
+			}
+		},
+		func(p *Post, r PostRelations) {
+			p.AuthorID = r.Author.ID
+			p.CategoryID = r.Category.ID
+		},
+	)
+
+	// Create custom associations
+	customAuthor := authorFactory.Build(func(a *Author) {
+		a.Name = "Custom Author"
+	})
+	customCategory := categoryFactory.Build(func(c *Category) {
+		c.Name = "Custom Category"
+	})
+
+	post := postFactory.WithCustomAssociations(PostRelations{
+		Author:   customAuthor,
+		Category: customCategory,
+	})
+
+	if post.AuthorID != customAuthor.ID {
+		t.Errorf("Post AuthorID (%d) should match custom Author ID (%d)", post.AuthorID, customAuthor.ID)
+	}
+
+	if post.CategoryID != customCategory.ID {
+		t.Errorf("Post CategoryID (%d) should match custom Category ID (%d)", post.CategoryID, customCategory.ID)
+	}
+}
+
+func TestAssociationFactory_WithTrait(t *testing.T) {
+	authorFactory := gofab.Define[Author]()
+	categoryFactory := gofab.Define[Category]()
+
+	postFactory := gofab.DefineWithAssociations[Post, PostRelations](
+		func() PostRelations {
+			return PostRelations{
+				Author:   authorFactory.Build(),
+				Category: categoryFactory.Build(),
+			}
+		},
+		func(p *Post, r PostRelations) {
+			p.AuthorID = r.Author.ID
+			p.CategoryID = r.Category.ID
+		},
+	).Trait("featured", func(p *Post) {
+		p.Title = "Featured Post"
+	})
+
+	post := postFactory.Build(postFactory.WithTrait("featured")...)
+
+	if post.Title != "Featured Post" {
+		t.Errorf("Post Title should be 'Featured Post', got '%s'", post.Title)
+	}
+
+	if post.AuthorID == 0 {
+		t.Error("Post AuthorID should still be set from association")
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -167,3 +167,47 @@ func Example_sequence() {
 	// Output:
 	// IDs are sequential: true
 }
+
+// Example_association demonstrates creating objects with associations.
+func Example_association() {
+	type Author struct {
+		ID   int    `gofab:"sequence"`
+		Name string `gofab:"name"`
+	}
+
+	type Post struct {
+		ID       int    `gofab:"sequence"`
+		Title    string `gofab:"sentence:3"`
+		AuthorID int
+	}
+
+	type PostRelations struct {
+		Author Author
+	}
+
+	authorFactory := Define[Author]()
+
+	postFactory := DefineWithAssociations[Post, PostRelations](
+		func() PostRelations {
+			return PostRelations{
+				Author: authorFactory.Build(),
+			}
+		},
+		func(p *Post, r PostRelations) {
+			p.AuthorID = r.Author.ID
+		},
+	)
+
+	post, relations := postFactory.BuildWithAssociations()
+
+	fmt.Printf("Post has ID: %v\n", post.ID > 0)
+	fmt.Printf("Post has Title: %v\n", post.Title != "")
+	fmt.Printf("Post linked to Author: %v\n", post.AuthorID == relations.Author.ID)
+	fmt.Printf("Author has Name: %v\n", relations.Author.Name != "")
+
+	// Output:
+	// Post has ID: true
+	// Post has Title: true
+	// Post linked to Author: true
+	// Author has Name: true
+}


### PR DESCRIPTION
## Summary
Add `AssociationFactory` for type-safe automatic related object creation, reducing boilerplate in tests with relationships.

### New API
```go
type PostRelations struct {
    Author   Author
    Category Category
}

postFactory := DefineWithAssociations[Post, PostRelations](
    func() PostRelations {
        return PostRelations{
            Author:   authorFactory.Build(),
            Category: categoryFactory.Build(),
        }
    },
    func(p *Post, r PostRelations) {
        p.AuthorID = r.Author.ID
        p.CategoryID = r.Category.ID
    },
)

// Automatically creates Author and Category, links them to Post
post := postFactory.Build()

// Get both the instance and its associations
post, relations := postFactory.BuildWithAssociations()
```

### Features
- `DefineWithAssociations[T, R]()` - Create factory with association support
- `Build()` - Automatically create and link associated objects
- `BuildWithAssociations()` - Return both instance and associations
- `BuildList()` / `BuildListWithAssociations()` - Create multiple instances
- `WithCustomAssociations()` - Override default associations
- Full Trait support

## Test plan
- [x] All existing tests pass
- [x] New tests for AssociationFactory (Build, BuildWithAssociations, BuildList, WithCustomAssociations, WithTrait)
- [x] New Example test for association usage
- [x] Lint checks pass