### PR TITLE
refactor: remove sequence tag from populate.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A simple and flexible factory pattern implementation for Go testing, inspired by
 - Type-safe factory definitions using generics
 - Automatic field population with struct tags
 - Build single or multiple instances
-- Sequence support for unique IDs
+- Sequence builder for unique IDs
+- Traits for reusable attribute sets
 - Customizable field overrides
 - Integration with faker for realistic test data
 
@@ -23,9 +24,9 @@ go get github.com/sivchari/gofab
 
 ```go
 type User struct {
-    ID    int    `gofab:"sequence"`
     Name  string `gofab:"name"`
     Email string `gofab:"email"`
+    Age   int    `gofab:"range:18,65"`
 }
 
 // Build a single user
@@ -74,7 +75,6 @@ admin := userFactory.Build(func(u *User) {
 
 gofab supports various struct tags for automatic field population:
 
-- `gofab:"sequence"` - Auto-incrementing ID
 - `gofab:"name"` - Random person name
 - `gofab:"email"` - Random email address
 - `gofab:"phone"` - Random phone number
@@ -103,17 +103,26 @@ func TestUserService(t *testing.T) {
 }
 ```
 
-### Sequence for Unique IDs
+### Sequence Builder for Unique IDs
+
+Use the `Sequence` builder for auto-incrementing values:
 
 ```go
 type Order struct {
-    ID     int `gofab:"sequence"`
+    ID     int
     Number string
 }
 
-order1 := gofab.Build[Order]() // ID: 1
-order2 := gofab.Build[Order]() // ID: 2
-order3 := gofab.Build[Order]() // ID: 3
+orderFactory := gofab.Define[Order](
+    gofab.Sequence(
+        func(o *Order, n int64) { o.ID = int(n) },
+        func(n int64) int64 { return n + 1 },
+    ),
+)
+
+order1 := orderFactory.Build() // ID: 1
+order2 := orderFactory.Build() // ID: 2
+order3 := orderFactory.Build() // ID: 3
 ```
 
 ### Traits for Reusable Attribute Sets

--- a/build_test.go
+++ b/build_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 type TestUser struct {
-	ID      int    `gofab:"sequence"`
+	ID      int    `gofab:"range:1,1000"`
 	Name    string `gofab:"name"`
 	Email   string `gofab:"email"`
 	Phone   string `gofab:"phone"`
@@ -32,7 +32,7 @@ func validatePopulatedFields(t *testing.T, user *TestUser) {
 	t.Helper()
 
 	if user.ID == 0 {
-		t.Error("ID should be populated by sequence")
+		t.Error("ID should be populated by range")
 	}
 
 	if user.Name == "" {
@@ -116,18 +116,13 @@ func TestBuildList(t *testing.T) {
 		t.Errorf("Expected 3 users, got %d", len(users))
 	}
 
-	// Check that all users have different sequence IDs
-	ids := make(map[int]bool)
+	// Check that each user has populated fields
 	for _, user := range users {
-		if ids[user.ID] {
-			t.Errorf("Duplicate ID found: %d", user.ID)
-		}
-
-		ids[user.ID] = true
-
-		// Check that each user has populated fields
 		if user.Name == "" || user.Email == "" {
 			t.Error("All users should have populated fields")
+		}
+		if user.ID == 0 {
+			t.Error("ID should be populated by range")
 		}
 	}
 }
@@ -149,20 +144,6 @@ func TestBuildListWithCustomizer(t *testing.T) {
 		if user.Name == "" {
 			t.Errorf("User %d should have auto-generated Name", i)
 		}
-	}
-}
-
-func TestSequenceIncrement(t *testing.T) {
-	user1 := gofab.Build[TestUser]()
-	user2 := gofab.Build[TestUser]()
-	user3 := gofab.Build[TestUser]()
-
-	if user2.ID != user1.ID+1 {
-		t.Errorf("Expected user2.ID to be %d, got %d", user1.ID+1, user2.ID)
-	}
-
-	if user3.ID != user2.ID+1 {
-		t.Errorf("Expected user3.ID to be %d, got %d", user2.ID+1, user3.ID)
 	}
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -7,18 +7,15 @@ import (
 // Example_build demonstrates the basic Build function.
 func Example_build() {
 	type User struct {
-		ID    int    `gofab:"sequence"`
 		Name  string `gofab:"name"`
 		Email string `gofab:"email"`
 	}
 
 	user := Build[User]()
-	fmt.Printf("Has ID: %v\n", user.ID > 0)
 	fmt.Printf("Has Name: %v\n", user.Name != "")
 	fmt.Printf("Has Email: %v\n", user.Email != "")
 
 	// Output:
-	// Has ID: true
 	// Has Name: true
 	// Has Email: true
 }
@@ -148,20 +145,23 @@ func Example_withTraits() {
 	// On Sale: true
 }
 
-// Example_sequence demonstrates the sequence tag for auto-incrementing IDs.
+// Example_sequence demonstrates the Sequence builder for auto-incrementing IDs.
 func Example_sequence() {
 	type Order struct {
-		ID int `gofab:"sequence"`
+		ID int
 	}
+
+	orderFactory := Define[Order](
+		Sequence(func(o *Order, n int64) { o.ID = int(n) }, func(n int64) int64 { return n + 1 }),
+	)
 
 	// Build multiple orders to show sequence
-	orders := make([]Order, 3)
-	for i := range orders {
-		orders[i] = Build[Order]()
-	}
+	order1 := orderFactory.Build()
+	order2 := orderFactory.Build()
+	order3 := orderFactory.Build()
 
 	// Check that IDs are sequential
-	sequential := orders[1].ID > orders[0].ID && orders[2].ID > orders[1].ID
+	sequential := order2.ID > order1.ID && order3.ID > order2.ID
 	fmt.Printf("IDs are sequential: %v\n", sequential)
 
 	// Output:

--- a/factory_test.go
+++ b/factory_test.go
@@ -12,7 +12,7 @@ const (
 )
 
 type IntegratedTestUser struct {
-	ID     int    `gofab:"sequence"`
+	ID     int    `gofab:"range:1,1000"`
 	Name   string `gofab:"name"`
 	Email  string `gofab:"email"`
 	Role   string // No tag - will be set by factory defaults
@@ -101,14 +101,11 @@ func TestFactoryBuildList(t *testing.T) {
 		t.Errorf("Expected 3 admins, got %d", len(admins))
 	}
 
-	// Check that all admins have unique IDs (sequence)
-	ids := make(map[int]bool)
+	// Check that all admins have IDs
 	for i, admin := range admins {
-		if ids[admin.ID] {
-			t.Errorf("Duplicate ID found: %d", admin.ID)
+		if admin.ID == 0 {
+			t.Errorf("Admin %d should have an ID", i)
 		}
-
-		ids[admin.ID] = true
 
 		// Check that each admin has the factory defaults
 		if admin.Role != roleAdmin {

--- a/populate.go
+++ b/populate.go
@@ -70,8 +70,6 @@ func handleTagGeneration(tag string, fieldType reflect.Type) any {
 		return handleSentenceTag(parts)
 	case "range":
 		return handleRangeTag(parts)
-	case "sequence":
-		return generateSequence(fieldType)
 	default:
 		return nil
 	}
@@ -107,39 +105,6 @@ func handleRangeTag(parts []string) any {
 	}
 
 	return gofakeit.Number(1, 100)
-}
-
-var sequenceCounters = make(map[reflect.Type]*sequenceCounter)
-
-func generateSequence(fieldType reflect.Type) any {
-	counter, exists := sequenceCounters[fieldType]
-	if !exists {
-		counter = &sequenceCounter{value: 0}
-		sequenceCounters[fieldType] = counter
-	}
-
-	next := counter.next()
-
-	switch fieldType.Kind() { //nolint:exhaustive // exhaustive switch is not necessary here
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return int(next)
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		if next < 0 {
-			return uint(0)
-		}
-
-		return uint(next)
-	case reflect.String:
-		return strconv.FormatInt(next, 10)
-	case reflect.Bool:
-		return next%2 == 0
-	case reflect.Float32:
-		return float32(next)
-	case reflect.Float64:
-		return float64(next)
-	default:
-		return int(next)
-	}
 }
 
 func setFieldValue(field reflect.Value, value any) {


### PR DESCRIPTION
## Summary

- Remove `gofab:"sequence"` struct tag functionality due to global state incompatibility with `t.Parallel()`
- Update documentation and examples to use the thread-safe `Sequence` builder

## Background

The `sequence` struct tag used a global `sequenceCounters` map, which causes race conditions when tests run in parallel. This was identified during PR review as a critical design flaw.

The `Sequence` builder in `sequence.go` is instance-scoped and thread-safe, making it the recommended approach for auto-incrementing IDs.

## Changes

- **populate.go**: Remove `sequenceCounters` global, `generateSequence` function, and `"sequence"` case
- **build_test.go**: Replace `gofab:"sequence"` with `gofab:"range:1,1000"`, remove `TestSequenceIncrement`
- **factory_test.go**: Replace `gofab:"sequence"` with `gofab:"range:1,1000"`
- **example_test.go**: Update `Example_sequence` to demonstrate `Sequence` builder usage
- **README.md**: Remove sequence tag documentation, update examples

## Test plan

- [x] All existing tests pass
- [x] Example tests updated and verified